### PR TITLE
Imperial weapons and aces fixes and limitation of upgrades per aircraft

### DIFF
--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="14" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="16" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="c4eb-077e-014a-c3c3" name="Thunderbolt Fury" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -533,7 +533,7 @@
             <characteristic name="FPR" typeId="a5ae-d9ef-f1b4-e838">2-6-0</characteristic>
             <characteristic name="DMG" typeId="3666-196d-11fd-c067">4+</characteristic>
             <characteristic name="AMMO" typeId="a495-a55a-5d79-5b94">UL</characteristic>
-            <characteristic name="SPECIAL" typeId="847c-0816-0714-4132">Extra Damage(6+)</characteristic>
+            <characteristic name="SPECIAL" typeId="847c-0816-0714-4132"/>
           </characteristics>
         </profile>
       </profiles>
@@ -573,13 +573,10 @@
             <characteristic name="FPR" typeId="a5ae-d9ef-f1b4-e838">3-7-0</characteristic>
             <characteristic name="DMG" typeId="3666-196d-11fd-c067">4+</characteristic>
             <characteristic name="AMMO" typeId="a495-a55a-5d79-5b94">UL</characteristic>
-            <characteristic name="SPECIAL" typeId="847c-0816-0714-4132">Extra Damage (6+)</characteristic>
+            <characteristic name="SPECIAL" typeId="847c-0816-0714-4132"></characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <infoLinks>
-        <infoLink id="57dd-f6ad-2061-053c" name="Extra Damage (6+)" hidden="false" targetId="2e4d-1b50-12f0-759f" type="profile"/>
-      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -247,10 +247,10 @@
       <entryLinks>
         <entryLink id="3555-2f49-5198-2d63" name="Autocannon" hidden="false" collective="false" import="true" targetId="f985-b481-f62e-c3b3" type="selectionEntry"/>
         <entryLink id="1c7c-c7f3-d05b-9fe6" name="Dorsal Turret" hidden="false" collective="false" import="true" targetId="bf14-339c-69e9-8246" type="selectionEntry"/>
-        <entryLink id="bc30-9682-d2b5-68bf" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2bb3-7dab-76d8-f4a3" type="selectionEntry"/>
         <entryLink id="e1af-2fef-076f-01e9" name="Bomb Bay" hidden="false" collective="false" import="true" targetId="582e-18ed-2f8a-c695" type="selectionEntry"/>
         <entryLink id="b7c0-e4bb-08a8-fa99" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="e4cd-90d4-2d78-b13e" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
+        <entryLink id="277b-18a3-c155-a213" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2999-92ad-5e6c-c912" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="27.0"/>
@@ -748,6 +748,30 @@
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2999-92ad-5e6c-c912" name="Rear Turret" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da57-61cb-2e3e-9b69" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6223-5914-28d8-2c8d" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="e799-82bc-ae0e-2411" name="Rear Turret" hidden="false" typeId="a0a8-9aaa-cb92-0e1e" typeName="Weapon">
+          <characteristics>
+            <characteristic name="FIRE ARC" typeId="3281-5ef2-68b5-0c24">Rear</characteristic>
+            <characteristic name="FPR" typeId="a5ae-d9ef-f1b4-e838">6-3-0</characteristic>
+            <characteristic name="DMG" typeId="3666-196d-11fd-c067">5+</characteristic>
+            <characteristic name="AMMO" typeId="a495-a55a-5d79-5b94">UL</characteristic>
+            <characteristic name="SPECIAL" typeId="847c-0816-0714-4132">Tail Gunner, Aerial Attack</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3db5-5f15-c060-d538" name="Aerial Attack" hidden="false" targetId="0d22-4d01-ff7f-b254" type="profile"/>
+        <infoLink id="0112-b19f-5f0f-1480" name="Tail Gunner" hidden="false" targetId="ec08-cc37-d171-9f2d" type="profile"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -792,8 +792,11 @@
         <entryLink id="c62d-f006-a2de-8390" name="Infra-red Targeting" hidden="false" collective="false" import="true" targetId="77fa-3981-f5ba-b21e" type="selectionEntry"/>
         <entryLink id="6961-c990-9f5a-cde0" name="Armoured Cockpit" hidden="false" collective="false" import="true" targetId="fbf4-5133-fb74-ab4e" type="selectionEntry"/>
         <entryLink id="483c-a7df-976b-612c" name="Imperial Ace" hidden="false" collective="false" import="true" targetId="104b-4ecf-c9e1-5688" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="3440-4044-7fda-fe24" value="0.0"/>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b012-2103-5c7c-fc09" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b012-2103-5c7c-fc09" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="13" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="14" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="c4eb-077e-014a-c3c3" name="Thunderbolt Fury" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -558,7 +558,7 @@
         <infoLink id="5fa2-9f40-baf9-5ac3" name="Extra Damage (6+)" hidden="false" targetId="2e4d-1b50-12f0-759f" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9543-aa37-4ab4-90ad" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -621,7 +621,7 @@
         <infoLink id="cf0d-6a91-1bdd-1692" name="Extra Damage (5+)" hidden="false" targetId="6cd3-39d8-bedc-56e6" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d98-bf4d-18da-f3b3" name="Pair of Skystrike Missiles" hidden="false" collective="false" import="true" type="upgrade">
@@ -641,7 +641,7 @@
         <infoLink id="e6be-6441-ba4c-5028" name="Extra Damage (6+)" hidden="false" targetId="2e4d-1b50-12f0-759f" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8678-00c1-4744-b174" name="Ejector Seats" hidden="false" collective="false" import="true" type="upgrade">

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -810,6 +810,9 @@
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="b890-18e0-99ff-65b2" name="Aircraft Upgrades" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b9a-0086-7bc0-feeb" type="max"/>
+      </constraints>
       <entryLinks>
         <entryLink id="0c9a-b286-0e1c-8955" name="Ejector Seats" hidden="false" collective="false" import="true" targetId="8678-00c1-4744-b174" type="selectionEntry"/>
         <entryLink id="9f92-1d11-0646-180d" name="Flares or Chaff Launcher" hidden="false" collective="false" import="true" targetId="05aa-0df1-2e49-916c" type="selectionEntry"/>

--- a/Ork_Air_Waaagh.cat
+++ b/Ork_Air_Waaagh.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="26" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="27" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="96a0-75b0-6b4a-645f" name="&apos;Eavy Flak Kannon" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -439,7 +439,6 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
-
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -555,18 +554,11 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="f0d3-a101-5526-f7d1" name="4 Bomms" hidden="false" collective="false" import="true" type="upgrade">
-              <modifiers>
-                <modifier type="set" field="a75a-6f56-7b1c-1864" value="0.0">
-                  <conditions>
-                    <condition field="selections" scope="8db8-8c06-939d-4614" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e42d-efe2-ca5c-532b" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a75a-6f56-7b1c-1864" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="3.0"/>
+                <cost name="pts" typeId="points" value="8.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -884,7 +876,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e42d-efe2-ca5c-532b" name="Kustom Big Shootas" hidden="false" collective="false" import="true" type="upgrade">
@@ -938,7 +930,7 @@
         <infoLink id="f8c1-5dad-81da-9954" name="Ground Attack" hidden="false" targetId="434d-a81a-c5e1-5f52" type="profile"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4130-d747-574e-8f51" name="Belching Smoke" hidden="false" collective="false" import="true" type="upgrade">
@@ -965,7 +957,7 @@
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="12fa-38c1-5723-750c" name="Wazmek Speshul" hidden="false" collective="false" import="true" type="upgrade">
@@ -1016,14 +1008,6 @@ If at the end of any Firing phase the Autonomous weapon occupies a hex adjacent 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6859-ec3d-2abf-a3da" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6847-d43d-667f-c1d3" name="Fly Boss" hidden="false" collective="false" import="true" targetId="8747-3089-7d21-882d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57ca-174d-d161-f714" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="2b19-de35-4fb0-90f1" name="Extra Armor" hidden="false" collective="false" import="true" targetId="5e1f-9540-97ad-5c0a" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e4-1b62-7429-149d" type="max"/>
@@ -1037,6 +1021,11 @@ If at the end of any Firing phase the Autonomous weapon occupies a hex adjacent 
         <entryLink id="7280-a609-777c-3c51" name="Kustom Big Shootas" hidden="false" collective="false" import="true" targetId="e42d-efe2-ca5c-532b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a151-2e1f-0caf-1e42" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5993-78ec-b867-6eaa" name="Fly Boss" hidden="false" collective="false" import="true" targetId="8747-3089-7d21-882d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4acf-5830-8fff-6a74" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>

--- a/Ork_Air_Waaagh.cat
+++ b/Ork_Air_Waaagh.cat
@@ -1002,6 +1002,9 @@ If at the end of any Firing phase the Autonomous weapon occupies a hex adjacent 
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="54a6-483f-3fbb-cf60" name="Aircraft upgrade" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a6-2f3a-f1d1-636f" type="max"/>
+      </constraints>
       <entryLinks>
         <entryLink id="5e93-1023-3093-7841" name="Belching Smoke" hidden="false" collective="false" import="true" targetId="4130-d747-574e-8f51" type="selectionEntry">
           <constraints>


### PR DESCRIPTION
- Only 2 aircraft upgrades per aircrafts are allowed
- Fixed Marauder destroyer rear turret stats
- Removed Extra Damage(6+) from Thunderbolt main guns