### PR TITLE
Added Optional Thunderhawk weapons

### DIFF
--- a/Adeptus_Astartes.cat
+++ b/Adeptus_Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="1" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="2" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="25d1-4c56-7d01-fd5b" name="Wrath of Angels" publicationDate="2021"/>
   </publications>
@@ -379,6 +379,24 @@
           </constraints>
           <entryLinks>
             <entryLink id="e710-d978-28d3-7e66" name="Twin Lascannon" hidden="false" collective="false" import="true" targetId="6961-d358-1e91-21f0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="518b-def7-2b6a-7ec3" name="Additional Weaponary" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d992-9c0b-7dc8-b6f6" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b908-c5a9-9453-1779" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7721-4c2d-8506-7de4" name="Pair of Wing Bombs" hidden="false" collective="false" import="true" targetId="9df5-dc2b-aaa6-3bdd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="aedf-4344-243a-6469" name="Pair of Hellstrike Missiles" hidden="false" collective="false" import="true" targetId="3542-be32-6955-4e11" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>


### PR DESCRIPTION
Extra weapons for Thunderhawk added (pair of hellstrike missiles and pair of wing bombs.)

Sorry, commited to master by mistake. Reverted and done via branch instead. The thunderhawk box comes with rules and lists the optional weapons as 3 of any at 2 points each. They do not replace any existing weapons.

![image](https://user-images.githubusercontent.com/1666415/140068823-26c72057-aa18-4cfe-b095-f86463a3e615.png)
