### PR TITLE
Add Expanded Ace Abilities

### DIFF
--- a/Adeptus_Astartes.cat
+++ b/Adeptus_Astartes.cat
@@ -60,7 +60,7 @@
           </constraints>
         </entryLink>
         <entryLink id="520b-1557-d9fd-80d0" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
-        <entryLink id="4c53-b640-d569-2e7a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="b975-4454-ddff-314f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -135,7 +135,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="859e-a7c0-4f8f-c445" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2874-e26b-98c6-071c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="cd14-c68c-8da5-6a2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="29.0"/>
@@ -308,7 +308,7 @@
           </constraints>
         </entryLink>
         <entryLink id="7972-a241-0089-a6e2" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
-        <entryLink id="6c7e-9b42-7bc8-9347" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="5d69-f642-6c22-4276" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="31.0"/>
@@ -406,7 +406,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3736-5dff-a152-a992" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
-        <entryLink id="453c-f05a-8933-6f71" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="94d7-f35a-3822-9f8e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="44.0"/>

--- a/Adeptus_Astartes.cat
+++ b/Adeptus_Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="7" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="9" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="25d1-4c56-7d01-fd5b" name="Wrath of Angels" publicationDate="2021"/>
   </publications>
@@ -60,6 +60,7 @@
           </constraints>
         </entryLink>
         <entryLink id="520b-1557-d9fd-80d0" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
+        <entryLink id="4c53-b640-d569-2e7a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -134,6 +135,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="859e-a7c0-4f8f-c445" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="2874-e26b-98c6-071c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="29.0"/>
@@ -306,6 +308,7 @@
           </constraints>
         </entryLink>
         <entryLink id="7972-a241-0089-a6e2" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
+        <entryLink id="6c7e-9b42-7bc8-9347" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="31.0"/>
@@ -403,6 +406,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3736-5dff-a152-a992" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
+        <entryLink id="453c-f05a-8933-6f71" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="44.0"/>

--- a/Aeldari_Asuryani.cat
+++ b/Aeldari_Asuryani.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="80cf-6e69-8bf6-d62e" name="Asuryani" revision="4" battleScribeVersion="2.03" authorName="Updated Companion Stats" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="80cf-6e69-8bf6-d62e" name="Asuryani" revision="5" battleScribeVersion="2.03" authorName="Updated Companion Stats" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1d81-06ef-f102-6d15" name="Wrath of Angels"/>
     <publication id="1ef7-1236-3c3d-7e72" name="Aeronautica Imperialis – Companion" shortName="Companion" publisher="Aeronautica Imperialis – Companion" publicationDate="2022" publisherUrl="https://www.games-workshop.com/en-CA/aeronautica-imperialis-companion-eng-2022"/>
@@ -189,6 +189,7 @@
           </constraints>
         </entryLink>
         <entryLink id="3aac-ff5d-a7fd-6aac" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
+        <entryLink id="5fb6-28f5-44f0-f937" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -265,6 +266,7 @@
           </constraints>
         </entryLink>
         <entryLink id="15ad-7e56-1233-077b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
+        <entryLink id="cb55-7761-3aad-a837" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -471,6 +473,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f414-f6fd-10d0-0545" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="5826-0768-f1e6-4b20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -518,6 +521,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b1b-182a-d995-9ae0" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="cb4e-4367-1aef-19a3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -594,6 +598,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4493-2b67-4f9e-6db9" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
+        <entryLink id="3227-3b87-29e5-e3cc" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>
@@ -638,6 +643,7 @@
           </constraints>
         </entryLink>
         <entryLink id="5c83-57c9-3634-5d74" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
+        <entryLink id="2226-490f-9896-b828" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="36.0"/>

--- a/Aeldari_Asuryani.cat
+++ b/Aeldari_Asuryani.cat
@@ -189,7 +189,7 @@
           </constraints>
         </entryLink>
         <entryLink id="3aac-ff5d-a7fd-6aac" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
-        <entryLink id="5fb6-28f5-44f0-f937" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="5fb6-28f5-44f0-f937" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -266,7 +266,7 @@
           </constraints>
         </entryLink>
         <entryLink id="15ad-7e56-1233-077b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
-        <entryLink id="cb55-7761-3aad-a837" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="cb55-7761-3aad-a837" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -473,7 +473,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f414-f6fd-10d0-0545" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5826-0768-f1e6-4b20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="5826-0768-f1e6-4b20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -521,7 +521,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b1b-182a-d995-9ae0" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="cb4e-4367-1aef-19a3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="cb4e-4367-1aef-19a3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -598,7 +598,7 @@
           </constraints>
         </entryLink>
         <entryLink id="4493-2b67-4f9e-6db9" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
-        <entryLink id="3227-3b87-29e5-e3cc" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="3227-3b87-29e5-e3cc" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>
@@ -643,7 +643,7 @@
           </constraints>
         </entryLink>
         <entryLink id="5c83-57c9-3634-5d74" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
-        <entryLink id="2226-490f-9896-b828" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="2226-490f-9896-b828" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="36.0"/>

--- a/Astra_Militarum.cat
+++ b/Astra_Militarum.cat
@@ -68,7 +68,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b7b2-4a5f-829b-9f91" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
-        <entryLink id="4c0e-19ea-a2dd-f376" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="4c0e-19ea-a2dd-f376" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -170,7 +170,7 @@
       <entryLinks>
         <entryLink id="4aff-27bb-a50b-192f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
         <entryLink id="ed71-33d8-66aa-b3b2" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="d466-fb90-0a26-33f8" type="selectionEntry"/>
-        <entryLink id="5a5e-d33a-79b3-4e2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="5a5e-d33a-79b3-4e2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>

--- a/Astra_Militarum.cat
+++ b/Astra_Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="63fd-f1bb-e3ca-e39f" name="Astra Militarum" revision="2" battleScribeVersion="2.03" authorName="Valkyrie Assault Craft" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="63fd-f1bb-e3ca-e39f" name="Astra Militarum" revision="3" battleScribeVersion="2.03" authorName="Valkyrie Assault Craft" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="9474-faac-1eb5-889b" name="Valkyrie Assault Craft" hidden="false" collective="false" import="true" type="model">
       <profiles>
@@ -68,6 +68,7 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b7b2-4a5f-829b-9f91" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
+        <entryLink id="4c0e-19ea-a2dd-f376" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -169,6 +170,7 @@
       <entryLinks>
         <entryLink id="4aff-27bb-a50b-192f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
         <entryLink id="ed71-33d8-66aa-b3b2" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="d466-fb90-0a26-33f8" type="selectionEntry"/>
+        <entryLink id="5a5e-d33a-79b3-4e2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -289,7 +291,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3907-c681-e24e-ab92" type="max"/>
       </constraints>
       <profiles>
-        <profile id="d06b-398d-dcc0-75fc" name="Armoured Transport Compartment" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="d06b-398d-dcc0-75fc" name="Armoured Transport Compartment" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">If the aircraft is reduced to 0 Structure oints and destroyed for any reason, roll a D6. On a 5+, the cargo of passengers safely escape and the aircraft is only worth 75% of its total points cost in Victory points, rather than the usual 100%</characteristic>
           </characteristics>
@@ -304,7 +306,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9353-a1c1-1ee7-2311" type="max"/>
       </constraints>
       <profiles>
-        <profile id="5fef-ea56-beaa-0b43" name="Tactical Targetting Array" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="5fef-ea56-beaa-0b43" name="Tactical Targetting Array" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">Once per game, when targetting an enemy aircraft with Air-to-Air fire, this aircraft may re-roll any of the Firepower dice that roll a 1 to hit.</characteristic>
           </characteristics>
@@ -319,7 +321,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee25-3a3d-da8b-1734" type="max"/>
       </constraints>
       <profiles>
-        <profile id="ba0a-90db-6fe7-32ac" name="Flares or Chaff Launcher" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="ba0a-90db-6fe7-32ac" name="Flares or Chaff Launcher" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">Once per game, if the aircraft is hit by a weapons with an armor characteristic of 1, 2, or 3, roll a D6. On a 6, the hit becomes a miss.</characteristic>
           </characteristics>
@@ -334,7 +336,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e71-32ab-7ef8-703f" type="max"/>
       </constraints>
       <profiles>
-        <profile id="d58e-00bd-b05c-b461" name="Infra-red Targeting" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="d58e-00bd-b05c-b461" name="Infra-red Targeting" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">If the Night Fighting or Bad Weather rule are in use, this aircraft may fire at Medium range without reducing the number of Firepower dice rolled.</characteristic>
           </characteristics>
@@ -349,7 +351,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a63-720c-f871-0d0d" type="max"/>
       </constraints>
       <profiles>
-        <profile id="9fd8-66be-432e-1f1b" name="Armored Cockpit" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="9fd8-66be-432e-1f1b" name="Armored Cockpit" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">When this aircraft suffers a damaging hit from enemy fire, roll a D6. On a 6, the damage is ignored and the Structure points(s) that would have been lost as a result of the damage dice are not lost.</characteristic>
           </characteristics>
@@ -433,7 +435,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57ee-cf7d-febb-80eb" type="max"/>
       </constraints>
       <profiles>
-        <profile id="7abd-80da-46df-28e6" name="Imperial Ace" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircarft Upgrade">
+        <profile id="7abd-80da-46df-28e6" name="Imperial Ace" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
           <characteristics>
             <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">Ths upgrade may only be taken by one aicraft within a force. Once per game, this aircraft may choose to re-roll a dice roll. However, all of the dice rolled must be re-rolled an the player must accept the result of the second roll, even if it is worse.</characteristic>
           </characteristics>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="24" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="15" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="25" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="583d-7042-2316-f8b5" name="White Dwarf October 2019"/>
     <publication id="39ba-445a-a65f-2bd6" name="White Dwarf November 2020"/>
@@ -62,6 +62,7 @@
         <entryLink id="ee65-22dd-e12f-3250" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="9543-aa37-4ab4-90ad" type="selectionEntry"/>
         <entryLink id="febc-5893-2bad-93a1" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="2f34-5a54-3085-8855" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
+        <entryLink id="804b-835e-7125-e869" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -124,6 +125,7 @@
         <entryLink id="ff1c-2239-9a19-a11a" name="Quad Autocannons" hidden="false" collective="false" import="true" targetId="34c9-9e57-7b5b-bb1c" type="selectionEntry"/>
         <entryLink id="dca6-d7e1-c904-2e50" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="d5fd-4934-7cf9-07bc" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
+        <entryLink id="0003-a8cd-ed9d-69b8" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -188,6 +190,7 @@
         <entryLink id="c97d-6c28-71e2-a5cc" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2bb3-7dab-76d8-f4a3" type="selectionEntry"/>
         <entryLink id="7868-bd41-6a69-93ff" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="5f8f-6c40-0768-a20d" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
+        <entryLink id="a19e-a3c6-eeb9-7f4f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -255,6 +258,7 @@
         <entryLink id="b7c0-e4bb-08a8-fa99" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="e4cd-90d4-2d78-b13e" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="277b-18a3-c155-a213" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2999-92ad-5e6c-c912" type="selectionEntry"/>
+        <entryLink id="f19e-ca4e-54f4-b678" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="27.0"/>
@@ -512,6 +516,7 @@
         <entryLink id="6f06-e3fd-ee1f-bca5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="0c59-ad35-ccba-d1de" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="b392-0a36-755e-8ac4" type="selectionEntry"/>
         <entryLink id="c487-1d86-ca05-2d39" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="9543-aa37-4ab4-90ad" type="selectionEntry"/>
+        <entryLink id="0376-61b7-f7bc-24b5" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -582,6 +587,7 @@
       <entryLinks>
         <entryLink id="4181-cb50-f402-47a1" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="7e06-d2b4-0a5d-8035" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
+        <entryLink id="3f33-5b82-00d3-9134" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="19.0"/>
@@ -613,6 +619,7 @@
       </categoryLinks>
       <entryLinks>
         <entryLink id="60a3-2ebb-1a8a-bfcf" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
+        <entryLink id="9473-df52-deed-d37f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
@@ -735,6 +742,7 @@
         <entryLink id="a81b-2c56-63f7-8ea5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="6842-a7b6-d615-db67" name="Colossus Bomb" hidden="false" collective="false" import="true" targetId="dc57-74a4-973b-d9cf" type="selectionEntry"/>
         <entryLink id="b815-d515-35e6-9daf" name="Heavy Bolter Array" hidden="false" collective="false" import="true" targetId="c35c-4da1-1099-b325" type="selectionEntry"/>
+        <entryLink id="234d-2f97-3ecb-3d20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -786,6 +794,7 @@
         <entryLink id="62e8-a751-f0f0-647c" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2bb3-7dab-76d8-f4a3" type="selectionEntry"/>
         <entryLink id="5301-87d4-abc7-8924" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="be3e-e330-38d7-e2a5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
+        <entryLink id="9811-fcc3-a179-50e3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -62,7 +62,7 @@
         <entryLink id="ee65-22dd-e12f-3250" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="9543-aa37-4ab4-90ad" type="selectionEntry"/>
         <entryLink id="febc-5893-2bad-93a1" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="2f34-5a54-3085-8855" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
-        <entryLink id="804b-835e-7125-e869" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="804b-835e-7125-e869" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -125,7 +125,7 @@
         <entryLink id="ff1c-2239-9a19-a11a" name="Quad Autocannons" hidden="false" collective="false" import="true" targetId="34c9-9e57-7b5b-bb1c" type="selectionEntry"/>
         <entryLink id="dca6-d7e1-c904-2e50" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="d5fd-4934-7cf9-07bc" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
-        <entryLink id="0003-a8cd-ed9d-69b8" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="0003-a8cd-ed9d-69b8" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -190,7 +190,7 @@
         <entryLink id="c97d-6c28-71e2-a5cc" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2bb3-7dab-76d8-f4a3" type="selectionEntry"/>
         <entryLink id="7868-bd41-6a69-93ff" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="5f8f-6c40-0768-a20d" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
-        <entryLink id="a19e-a3c6-eeb9-7f4f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="a19e-a3c6-eeb9-7f4f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -258,7 +258,7 @@
         <entryLink id="b7c0-e4bb-08a8-fa99" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="e4cd-90d4-2d78-b13e" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="277b-18a3-c155-a213" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2999-92ad-5e6c-c912" type="selectionEntry"/>
-        <entryLink id="f19e-ca4e-54f4-b678" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="f19e-ca4e-54f4-b678" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="27.0"/>
@@ -516,7 +516,7 @@
         <entryLink id="6f06-e3fd-ee1f-bca5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="0c59-ad35-ccba-d1de" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="b392-0a36-755e-8ac4" type="selectionEntry"/>
         <entryLink id="c487-1d86-ca05-2d39" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="9543-aa37-4ab4-90ad" type="selectionEntry"/>
-        <entryLink id="0376-61b7-f7bc-24b5" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="0376-61b7-f7bc-24b5" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -587,7 +587,7 @@
       <entryLinks>
         <entryLink id="4181-cb50-f402-47a1" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="7e06-d2b4-0a5d-8035" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
-        <entryLink id="3f33-5b82-00d3-9134" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="3f33-5b82-00d3-9134" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="19.0"/>
@@ -619,7 +619,7 @@
       </categoryLinks>
       <entryLinks>
         <entryLink id="60a3-2ebb-1a8a-bfcf" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
-        <entryLink id="9473-df52-deed-d37f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="9473-df52-deed-d37f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
@@ -742,7 +742,7 @@
         <entryLink id="a81b-2c56-63f7-8ea5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="6842-a7b6-d615-db67" name="Colossus Bomb" hidden="false" collective="false" import="true" targetId="dc57-74a4-973b-d9cf" type="selectionEntry"/>
         <entryLink id="b815-d515-35e6-9daf" name="Heavy Bolter Array" hidden="false" collective="false" import="true" targetId="c35c-4da1-1099-b325" type="selectionEntry"/>
-        <entryLink id="234d-2f97-3ecb-3d20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="234d-2f97-3ecb-3d20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -794,7 +794,7 @@
         <entryLink id="62e8-a751-f0f0-647c" name="Rear Turret" hidden="false" collective="false" import="true" targetId="2bb3-7dab-76d8-f4a3" type="selectionEntry"/>
         <entryLink id="5301-87d4-abc7-8924" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="be3e-e330-38d7-e2a5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
-        <entryLink id="9811-fcc3-a179-50e3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="9811-fcc3-a179-50e3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>

--- a/Necron.cat
+++ b/Necron.cat
@@ -42,7 +42,7 @@
           </constraints>
         </entryLink>
         <entryLink id="97f2-1a9c-e7ea-2771" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
-        <entryLink id="8663-2df7-c685-d3dd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="6693-6551-76de-399c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="38.0"/>
@@ -85,7 +85,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2136-0bd3-ca46-7e7c" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
-        <entryLink id="0b92-0352-6eae-694a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="b880-20b6-5d0f-c3b3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="39.0"/>
@@ -123,7 +123,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a3ac-35f6-6f8b-ea4f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
-        <entryLink id="d662-855c-3354-a88a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="6ac5-6326-0d73-3829" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>

--- a/Necron.cat
+++ b/Necron.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a13a-71d9-db49-a498" name="Necrons" revision="2" battleScribeVersion="2.03" authorName="Necron aircraft upgrades" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a13a-71d9-db49-a498" name="Necrons" revision="3" battleScribeVersion="2.03" authorName="Necron aircraft upgrades" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="41a0-328f-4c30-b6fa" name="Aeronautica Imperialis – Companion" shortName="Companion" publisher="Aeronautica Imperialis – Companion" publicationDate="2022" publisherUrl="https://www.games-workshop.com/en-CA/aeronautica-imperialis-companion-eng-2022"/>
   </publications>
@@ -42,6 +42,7 @@
           </constraints>
         </entryLink>
         <entryLink id="97f2-1a9c-e7ea-2771" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
+        <entryLink id="8663-2df7-c685-d3dd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="38.0"/>
@@ -84,6 +85,7 @@
           </constraints>
         </entryLink>
         <entryLink id="2136-0bd3-ca46-7e7c" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
+        <entryLink id="0b92-0352-6eae-694a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="39.0"/>
@@ -121,6 +123,7 @@
           </constraints>
         </entryLink>
         <entryLink id="a3ac-35f6-6f8b-ea4f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
+        <entryLink id="d662-855c-3354-a88a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>

--- a/Ork_Air_Waaagh.cat
+++ b/Ork_Air_Waaagh.cat
@@ -213,7 +213,7 @@
         </entryLink>
         <entryLink id="a05b-49b7-24b4-bcad" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="bdc3-540a-c180-2afb" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
-        <entryLink id="cf70-b292-660a-f695" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="cf70-b292-660a-f695" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -335,7 +335,7 @@
         </entryLink>
         <entryLink id="8ddb-6a39-69e2-c99a" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="fc09-69c3-0013-2f3f" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
-        <entryLink id="93b3-3d68-5b28-5e63" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="93b3-3d68-5b28-5e63" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -444,7 +444,7 @@
         </entryLink>
         <entryLink id="95b0-7d7f-7fe8-4ef9" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="2e38-d153-3519-07cc" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
-        <entryLink id="6eb6-5b04-19f7-4a11" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="6eb6-5b04-19f7-4a11" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -573,7 +573,7 @@
             <entryLink id="d4de-f5f3-c0c2-a5e7" name="Rudok Redz" hidden="false" collective="false" import="true" targetId="f7a5-fc3d-2b2a-0fb3" type="selectionEntry"/>
           </entryLinks>
         </entryLink>
-        <entryLink id="639b-ace7-b219-4b4b" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="639b-ace7-b219-4b4b" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -780,7 +780,7 @@
         <entryLink id="82f8-9b3e-14d3-666f" name="Tail Big Shoota" hidden="false" collective="false" import="true" targetId="d452-8858-d29e-a43a" type="selectionEntry"/>
         <entryLink id="519f-5511-7ff0-36ee" name="Mega Bomb" hidden="false" collective="false" import="true" targetId="242a-7b89-4093-dce5" type="selectionEntry"/>
         <entryLink id="86a7-eda8-b83b-58b1" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
-        <entryLink id="1108-6e8b-c5b1-dddd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="1108-6e8b-c5b1-dddd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="51.0"/>
@@ -847,6 +847,7 @@
         </entryLink>
         <entryLink id="8663-7831-5170-20b6" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="50cf-85b3-ea0a-8a7d" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
+        <entryLink id="1d4a-0f6d-f9e7-5d30" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -937,6 +938,7 @@
         </entryLink>
         <entryLink id="5d2b-f8d0-dca6-01ca" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="e2f4-1edb-8425-4671" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
+        <entryLink id="6f8e-60f8-cbb5-2490" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>

--- a/Ork_Air_Waaagh.cat
+++ b/Ork_Air_Waaagh.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="33" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="34" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="583d-7042-2316-f8b5" name="White Dwarf October 2019"/>
     <publication id="22c5-f0a4-5370-5716" name="White Dwarf December 2019"/>
@@ -213,6 +213,7 @@
         </entryLink>
         <entryLink id="a05b-49b7-24b4-bcad" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="bdc3-540a-c180-2afb" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
+        <entryLink id="cf70-b292-660a-f695" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -334,6 +335,7 @@
         </entryLink>
         <entryLink id="8ddb-6a39-69e2-c99a" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="fc09-69c3-0013-2f3f" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
+        <entryLink id="93b3-3d68-5b28-5e63" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -442,6 +444,7 @@
         </entryLink>
         <entryLink id="95b0-7d7f-7fe8-4ef9" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="2e38-d153-3519-07cc" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
+        <entryLink id="6eb6-5b04-19f7-4a11" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -570,6 +573,7 @@
             <entryLink id="d4de-f5f3-c0c2-a5e7" name="Rudok Redz" hidden="false" collective="false" import="true" targetId="f7a5-fc3d-2b2a-0fb3" type="selectionEntry"/>
           </entryLinks>
         </entryLink>
+        <entryLink id="639b-ace7-b219-4b4b" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -776,6 +780,7 @@
         <entryLink id="82f8-9b3e-14d3-666f" name="Tail Big Shoota" hidden="false" collective="false" import="true" targetId="d452-8858-d29e-a43a" type="selectionEntry"/>
         <entryLink id="519f-5511-7ff0-36ee" name="Mega Bomb" hidden="false" collective="false" import="true" targetId="242a-7b89-4093-dce5" type="selectionEntry"/>
         <entryLink id="86a7-eda8-b83b-58b1" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
+        <entryLink id="1108-6e8b-c5b1-dddd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="51.0"/>

--- a/Tau_Air_Caste.cat
+++ b/Tau_Air_Caste.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6088-0c35-9d44-ed62" name="T&apos;au Air Caste" revision="6" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="18" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6088-0c35-9d44-ed62" name="T&apos;au Air Caste" revision="7" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="8fd6-64b7-db74-8a38" name="Tau" hidden="true"/>
     <categoryEntry id="8b49-06f2-7beb-4695" name="Auxiliary" hidden="true">
@@ -85,6 +85,7 @@
             <cost name="pts" typeId="points" value="2.0"/>
           </costs>
         </entryLink>
+        <entryLink id="482f-29af-7520-0e10" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -155,6 +156,7 @@
             <cost name="pts" typeId="points" value="2.0"/>
           </costs>
         </entryLink>
+        <entryLink id="ce36-de89-b709-3ba9" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -215,6 +217,7 @@
         <entryLink id="7d50-29cb-fcb1-b3cb" name="Missile Pods" hidden="false" collective="false" import="true" targetId="3dc4-721f-c76d-a8cd" type="selectionEntry"/>
         <entryLink id="1d31-46f4-fc68-f61f" name="Drones" hidden="false" collective="false" import="true" targetId="56a2-e25b-7af2-469c" type="selectionEntryGroup"/>
         <entryLink id="42cf-0fb3-322e-ee75" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
+        <entryLink id="cc61-9d4b-806b-842e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -260,6 +263,7 @@
         <entryLink id="79cc-25a8-8336-846b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
         <entryLink id="f428-8d40-74e4-48c4" name="Seeker Missiles" hidden="false" collective="false" import="true" targetId="5800-b91e-1d0f-3c83" type="selectionEntry"/>
         <entryLink id="bed4-25f7-a545-bb12" name="Burst Cannon" hidden="false" collective="false" import="true" targetId="9a4b-5dab-27d5-c6f6" type="selectionEntry"/>
+        <entryLink id="aecf-0800-5663-5e4c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="14.0"/>
@@ -463,6 +467,7 @@
         <entryLink id="627e-1a55-a369-63e0" name="Quad Autocannons" hidden="false" collective="false" import="true" targetId="e972-d469-bca9-3ef2" type="selectionEntry"/>
         <entryLink id="66c4-4149-5d1e-0e48" name="Aircraft Upgrades (Aux)" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="8815-1dc9-41e3-b8f2" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
+        <entryLink id="caa5-2340-7d43-e00f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -532,6 +537,7 @@
         <entryLink id="9ba4-15c3-21fd-0e05" name="Rear Turret" hidden="false" collective="false" import="true" targetId="a225-dae4-ec77-979a" type="selectionEntry"/>
         <entryLink id="8fba-fd0e-f462-3a0a" name="Human Auxiliary Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="8720-456f-7f2a-07a0" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
+        <entryLink id="8edc-6648-debd-9f7e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -590,6 +596,7 @@
         <entryLink id="d0e8-11f6-4741-fcab" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="c541-381b-1314-ce28" name="Human Auxiliary Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="707b-aecc-053d-e0b1" name="Twin Lascannons" hidden="false" collective="false" import="true" targetId="ba94-bb2f-2e9c-b955" type="selectionEntry"/>
+        <entryLink id="06fa-385f-7ccc-2686" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -677,6 +684,7 @@
         <entryLink id="52da-e0c0-78bf-7804" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="8f57-3af5-4908-8f3b" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="9360-91dd-0f97-9175" type="selectionEntry"/>
         <entryLink id="2880-0be8-33b7-b516" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="6782-9d65-0c1c-0ab9" type="selectionEntry"/>
+        <entryLink id="68cc-b9cd-b86c-a16a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -771,6 +779,9 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="46bc-8370-1d66-2d07" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
       </costs>

--- a/Tau_Air_Caste.cat
+++ b/Tau_Air_Caste.cat
@@ -85,7 +85,7 @@
             <cost name="pts" typeId="points" value="2.0"/>
           </costs>
         </entryLink>
-        <entryLink id="482f-29af-7520-0e10" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="482f-29af-7520-0e10" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -156,7 +156,7 @@
             <cost name="pts" typeId="points" value="2.0"/>
           </costs>
         </entryLink>
-        <entryLink id="ce36-de89-b709-3ba9" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="ce36-de89-b709-3ba9" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -217,7 +217,7 @@
         <entryLink id="7d50-29cb-fcb1-b3cb" name="Missile Pods" hidden="false" collective="false" import="true" targetId="3dc4-721f-c76d-a8cd" type="selectionEntry"/>
         <entryLink id="1d31-46f4-fc68-f61f" name="Drones" hidden="false" collective="false" import="true" targetId="56a2-e25b-7af2-469c" type="selectionEntryGroup"/>
         <entryLink id="42cf-0fb3-322e-ee75" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
-        <entryLink id="cc61-9d4b-806b-842e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="cc61-9d4b-806b-842e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -263,7 +263,7 @@
         <entryLink id="79cc-25a8-8336-846b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
         <entryLink id="f428-8d40-74e4-48c4" name="Seeker Missiles" hidden="false" collective="false" import="true" targetId="5800-b91e-1d0f-3c83" type="selectionEntry"/>
         <entryLink id="bed4-25f7-a545-bb12" name="Burst Cannon" hidden="false" collective="false" import="true" targetId="9a4b-5dab-27d5-c6f6" type="selectionEntry"/>
-        <entryLink id="aecf-0800-5663-5e4c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="aecf-0800-5663-5e4c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="14.0"/>
@@ -467,7 +467,7 @@
         <entryLink id="627e-1a55-a369-63e0" name="Quad Autocannons" hidden="false" collective="false" import="true" targetId="e972-d469-bca9-3ef2" type="selectionEntry"/>
         <entryLink id="66c4-4149-5d1e-0e48" name="Aircraft Upgrades (Aux)" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="8815-1dc9-41e3-b8f2" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
-        <entryLink id="caa5-2340-7d43-e00f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="caa5-2340-7d43-e00f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -537,7 +537,7 @@
         <entryLink id="9ba4-15c3-21fd-0e05" name="Rear Turret" hidden="false" collective="false" import="true" targetId="a225-dae4-ec77-979a" type="selectionEntry"/>
         <entryLink id="8fba-fd0e-f462-3a0a" name="Human Auxiliary Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="8720-456f-7f2a-07a0" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
-        <entryLink id="8edc-6648-debd-9f7e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="8edc-6648-debd-9f7e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -596,7 +596,7 @@
         <entryLink id="d0e8-11f6-4741-fcab" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="c541-381b-1314-ce28" name="Human Auxiliary Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="ccb0-29d4-9aaf-b8d5" type="selectionEntryGroup"/>
         <entryLink id="707b-aecc-053d-e0b1" name="Twin Lascannons" hidden="false" collective="false" import="true" targetId="ba94-bb2f-2e9c-b955" type="selectionEntry"/>
-        <entryLink id="06fa-385f-7ccc-2686" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="06fa-385f-7ccc-2686" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -684,7 +684,7 @@
         <entryLink id="52da-e0c0-78bf-7804" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="8f57-3af5-4908-8f3b" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="9360-91dd-0f97-9175" type="selectionEntry"/>
         <entryLink id="2880-0be8-33b7-b516" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="6782-9d65-0c1c-0ab9" type="selectionEntry"/>
-        <entryLink id="68cc-b9cd-b86c-a16a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="68cc-b9cd-b86c-a16a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -718,7 +718,7 @@
         <categoryLink id="2acc-65ee-c7a8-bce5" name="Aux2" hidden="false" targetId="8b49-06f2-7beb-4695" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="98a0-24ad-de8a-2eba" name="Main Weapon" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="98a0-24ad-de8a-2eba" name="Main Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="eb2d-9e9c-a03a-0d83">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8c8-8256-fd27-2eee" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32d7-f030-8641-51da" type="max"/>
@@ -780,7 +780,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="46bc-8370-1d66-2d07" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="513e-d0ec-52f3-de73" type="selectionEntryGroup"/>
+        <entryLink id="46bc-8370-1d66-2d07" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -1350,6 +1350,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="ba94-bb2f-2e9c-b955" name="Twin Lascannons" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="9081-94ce-0974-6078" value="0.0">
+          <conditions>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe4c-3718-d781-0685" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db30-13dc-216b-787f" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9081-94ce-0974-6078" type="min"/>
@@ -1465,7 +1472,6 @@
       <comment>This is probably supposed to be twin lascannons, it has the same profile as them. No FAQ yet so we&apos;ll stick with this for now.</comment>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99d3-aa27-5e21-6037" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ec9-a9f8-5af3-5a98" type="min"/>
       </constraints>
       <profiles>
         <profile id="73ed-1171-1929-4a10" name="Lascannon" hidden="false" typeId="a0a8-9aaa-cb92-0e1e" typeName="Weapon">

--- a/Warhammer_40,000_Aeronautica_Imperialis.gst
+++ b/Warhammer_40,000_Aeronautica_Imperialis.gst
@@ -78,319 +78,284 @@
     </forceEntry>
   </forceEntries>
   <sharedSelectionEntries>
-    <selectionEntry id="2b40-fac7-feda-7c95" name="Aerial Predator" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="ee90-e85b-e6cb-6e0f" name="Aerial Predator" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level below it.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
+    <selectionEntry id="9212-4467-e7a2-ed52" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="05ff-c1dc-6058-b39b" name="Aerial Predator" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa1-8a97-3aec-5a10" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a82f-1dcc-30a0-cf21" name="Aerial Predator" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level below it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e96-1b38-f13b-bb7e" name="Cool-headed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b341-2ad9-3b51-f61d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9a7c-2707-1303-3652" name="Cool-headed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Stall with this aircraft.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="070d-b61b-5c88-4fd7" name="Crack Shot" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4787-0136-cf74-439f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a334-c989-a1c6-feab" name="Crack Shot" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, after rolling the Firepower dice but before rolling the Damage dice, this aircraft may choose to improve the Damage characteristic of one of its weapons by 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="06fd-7fc4-5a27-27a3" name="Dead-eye" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2971-7861-20d5-a1ce" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a370-4d47-c723-bb20" name="Dead-eye" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Short range.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="60b2-a21d-19a0-1a1f" name="Deadly Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="776c-8690-9361-2293" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8d33-f683-32c0-e27c" name="Deadly Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when resolving Tailing Fire.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c046-ed20-176c-8b27" name="Defensive Manoeuvre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9c-0068-c760-edc3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3e6b-0842-2205-a3a4" name="Defensive Manoeuvre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per turn, one enemy aircraft must discard one successful hit dice roll when targeting this aircraft.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6514-5659-2c10-dd50" name="Eagle-eyed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f1-3cf0-9d71-aeec" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="698c-1bd4-e83a-4db1" name="Eagle-eyed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Long range.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="02de-62fa-1c6d-2702" name="Enhanced Targeting" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c89-82ea-a143-28e8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="53bc-2810-598f-cc51" name="Enhanced Targeting" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft travelling at a ghigher Speed than it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f71c-9f5a-c3de-0029" name="Fly By" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="402f-7864-3bdc-75cd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="83a5-8525-e11e-9522" name="Fly By" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all Short range hit rolls made by this aircraft when targeting enemy aircraft travelling at a lower Speed than it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3656-1cc1-a9f0-9e51" name="Ground Attack Specialist" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7a6-10f6-d388-b18d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f76e-3420-1786-86f0" name="Ground Attack Specialist" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when firing a weapon with the Ground Attack special rule, this aircraft may re-roll any of the Firepower dice that roll a 1 to hit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="447f-4ce3-76db-9d3d" name="Large Calibre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e9-90a5-1415-0d30" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1b6f-b396-24bf-a816" name="Large Calibre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, this aircraft may improve the Damage characteristic of one of its weapons by 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="22a4-7874-4318-c249" name="No Fear" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82fb-5e8a-9642-50fb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="86a0-b4f8-1528-656b" name="No Fear" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Should this aircraft suffer any damaging hits as a result of ending its movement in a hex occupied by another aircraft, roll a D6 for each hit. For each roll of a 5+, a single damaging hit is ignored and the Structure point(s) that would have been lost as a result of the Damage dice are not lost.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5b7e-7caa-2f9c-c12e" name="Out of the Sun" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa2-edda-ef16-28fd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="74d9-1898-8f16-ef6e" name="Out of the Sun" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the Initiative roll if this aircraft is at a higher Altitude level than all enemy aircraft during the Initiative phase. A maximum of 1 can be added to the roll no matter how many pilots have this ability.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3f9e-7199-0dae-88f5" name="Precision Bombing" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d69-b3b6-5826-c168" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="125a-b05d-034a-97a5" name="Precision Bombing" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When making a Bombing Run, this aircraft adds +2 to the hit roll if there is only one level of Altitude difference between it and its target rather than the usual +1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f15c-59c3-1e52-e82c" name="Punch It!" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f13b-5699-f5f6-039c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef3d-6ba3-8814-9c60" name="Punch It!" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may add +1 to it Throttle characteristic when increasing Speed during the Throttle step of the Movement phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="17ab-0150-1ac2-67b2" name="Stealthy Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e89-478d-aac4-81a7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5cc9-b8db-0c1e-a550" name="Stealthy Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level above it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee86-c1a9-c874-13ae" name="Superior Reactions" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e811-2fd7-1fcc-e07e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="09b9-1bce-730b-4fac" name="Superior Reactions" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when this aircraft is activated during the Movement phase, it may discard its Manoeuvre token and immediately choose another Ace Manoeuvre.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f2a0-f494-549d-8a73" name="Survival Instinct" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ab-dda0-8df4-721b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="edfd-31af-7b7c-8cc8" name="Survival Instinct" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Spin with this aircraft.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
-        <cost name="pts" typeId="points" value="4.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0acb-a7ca-1a8b-ff7e" name="Out of the Sun" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="6493-5acd-04a2-9d52" name="Out of the Sun" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the Initiative roll if this aircraft is at a higher Altitude level than all enemy aircraft during the Initiative phase. A maximum of 1 can be added to the roll no matter how many pilots have this ability.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="df3e-9e42-f02f-5518" name="Precision Bombing" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="656c-cf3d-29a9-cd09" name="Precision Bombing" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When making a Bombing Run, this aircraft adds +2 to the hit roll if there is only one level of Altitude difference between it and its target rather than the usual +1.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d3f4-5a43-9f57-59ab" name="Cool-headed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="5ad0-ecb9-6179-3912" name="Cool-headed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Stall with this aircraft.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4cb1-1c8e-3c68-98b2" name="Deadly Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="f47d-6e27-42ad-55ba" name="Deadly Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when resolving Tailing Fire.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d80e-84a9-9d98-71c8" name="Dead-eye" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="7c33-0fb9-bc07-8412" name="Dead-eye" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Short range.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fc94-5fe4-d040-2839" name="Punch It!" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="638f-a0cd-8a10-da8e" name="Punch It!" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may add +1 to it Throttle characteristic when increasing Speed during the Throttle step of the Movement phase.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c02c-819b-9938-830c" name="Defensive Manoeuvre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="33c0-89ce-f8b6-77e5" name="Defensive Manoeuvre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per turn, one enemy aircraft must discard one successful hit dice roll when targeting this aircraft.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1b27-b64a-74ed-33a2" name="Superior Reactions" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="a9e8-00e0-a84d-b453" name="Superior Reactions" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when this aircraft is activated during the Movement phase, it may discard its Manoeuvre token and immediately choose another Ace Manoeuvre.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b55e-a77c-9b57-3713" name="Enhanced Targeting" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="8c3e-f078-d099-2799" name="Enhanced Targeting" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft travelling at a ghigher Speed than it.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e111-92b7-42fb-ecdd" name="No Fear" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="6d52-2324-67d8-2464" name="No Fear" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Should this aircraft suffer any damaging hits as a result of ending its movement in a hex occupied by another aircraft, roll a D6 for each hit. For each roll of a 5+, a single damaging hit is ignored and the Structure point(s) that would have been lost as a result of the Damage dice are not lost.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c493-09e6-bd9b-ab94" name="Survival Instinct" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="2409-a017-a6e8-fbf5" name="Survival Instinct" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Spin with this aircraft.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="1.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="08f0-8fe5-1051-32b2" name="Large Calibre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="382e-4456-9ef8-1736" name="Large Calibre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, this aircraft may improve the Damage characteristic of one of its weapons by 1.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3109-c829-5826-76a5" name="Ground Attack Specialist" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="e4ab-8c89-f874-b494" name="Ground Attack Specialist" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when firing a weapon with the Ground Attack special rule, this aircraft may re-roll any of the Firepower dice that roll a 1 to hit.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f1ec-1cb5-a366-eac0" name="Fly By" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="99d4-33d0-7e0d-e448" name="Fly By" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all Short range hit rolls made by this aircraft when targeting enemy aircraft travelling at a lower Speed than it.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="824b-31cb-e74a-9ab3" name="Stealthy Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="1b4a-c41c-ca0c-2eeb" name="Stealthy Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level above it.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="4.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="dc67-3b0e-60ac-1ba3" name="Crack Shot" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="6e58-74f7-4755-2c7b" name="Crack Shot" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, after rolling the Firepower dice but before rolling the Damage dice, this aircraft may choose to improve the Damage characteristic of one of its weapons by 1.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="4.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5acf-4a09-fdea-9b16" name="Eagle-eyed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="cef1-bdb3-bad2-3430" name="Eagle-eyed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-          <characteristics>
-            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Long range.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name="pts" typeId="points" value="4.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
-  <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="513e-d0ec-52f3-de73" name="Expanded Ace Abilities" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true">
-      <entryLinks>
-        <entryLink id="414f-ac52-3539-9865" name="Aerial Predator" hidden="false" collective="false" import="true" targetId="2b40-fac7-feda-7c95" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8e-fdd0-fcb4-34dd" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="edc2-fa42-672b-183a" name="Cool-headed" hidden="false" collective="false" import="true" targetId="d3f4-5a43-9f57-59ab" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab8c-da25-cb38-e93b" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="ca90-d067-b51a-37c8" name="Crack Shot" hidden="false" collective="false" import="true" targetId="dc67-3b0e-60ac-1ba3" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0501-f36b-e18b-943c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="641e-735f-d999-224a" name="Dead-eye" hidden="false" collective="false" import="true" targetId="d80e-84a9-9d98-71c8" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8029-05da-8418-8f3f" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="71a9-cb3a-9f90-cf24" name="Deadly Hunter" hidden="false" collective="false" import="true" targetId="4cb1-1c8e-3c68-98b2" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="138e-561a-0918-06d0" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="e82a-95f7-515b-4d12" name="Defensive Manoeuvre" hidden="false" collective="false" import="true" targetId="c02c-819b-9938-830c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0b7-d384-45c2-23d3" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="497c-cde4-935e-7360" name="Eagle-eyed" hidden="false" collective="false" import="true" targetId="5acf-4a09-fdea-9b16" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="981b-0b0b-7b0f-99e8" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="dd97-4c16-6d5d-ead0" name="Enhanced Targeting" hidden="false" collective="false" import="true" targetId="b55e-a77c-9b57-3713" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00b8-08cc-01f4-fe8d" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="4963-495a-cbf2-eac3" name="Fly By" hidden="false" collective="false" import="true" targetId="f1ec-1cb5-a366-eac0" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43f-0944-d17e-43df" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="c38e-6298-0f21-80fb" name="Ground Attack Specialist" hidden="false" collective="false" import="true" targetId="3109-c829-5826-76a5" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c4-cfad-e64f-8631" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="b7fa-d015-51f1-f12a" name="Large Calibre" hidden="false" collective="false" import="true" targetId="08f0-8fe5-1051-32b2" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f1c-ecb1-3c9f-773c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="9abd-04d2-f836-dbae" name="No Fear" hidden="false" collective="false" import="true" targetId="e111-92b7-42fb-ecdd" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-4c7d-94b4-e27c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="2db8-6570-6ebf-3ad5" name="Out of the Sun" hidden="false" collective="false" import="true" targetId="0acb-a7ca-1a8b-ff7e" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93c0-1cb6-6f8c-7eca" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="9491-f041-8e10-99b8" name="Precision Bombing" hidden="false" collective="false" import="true" targetId="df3e-9e42-f02f-5518" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f88-dee2-5ece-d7c2" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="5bd3-cafb-9408-09ab" name="Punch It!" hidden="false" collective="false" import="true" targetId="fc94-5fe4-d040-2839" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91d0-2a26-e243-07e9" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="7e28-ba24-7c52-8995" name="Stealthy Hunter" hidden="false" collective="false" import="true" targetId="824b-31cb-e74a-9ab3" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa7c-dc9f-0dd5-219e" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="7784-92ce-a601-af68" name="Superior Reactions" hidden="false" collective="false" import="true" targetId="1b27-b64a-74ed-33a2" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a41f-c173-16d0-482d" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="6ea5-0d3b-24d5-35d6" name="Survival Instinct" hidden="false" collective="false" import="true" targetId="c493-09e6-bd9b-ab94" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a5-f094-389c-0259" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-    </selectionEntryGroup>
-  </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="7406-f5b9-a751-1291" name="Jump troops" hidden="false">
       <description>Instead of landing in a landing zone, a transport aircraft with Jump Troops can drop them from altitude as it passes over. To drop its Jump Troops, the aircraft must pass directly over the landing zone during the Move and Manoeuvre step of the Movement phase. Once the aircraft has completed its movement, before adjusting Altitude roll a D6 for each point of transport capacity being dropped. If the result of the roll is higher than the aircraft’s current Altitude and Speed added together, the Jump Troops land safely within the landing zone and Victory points are scored. If however the result of the roll is equal to or lower than the aircraft’s current Speed and Altitude added together, the troops are scattered, injured or killed and no Victory points are scored.</description>

--- a/Warhammer_40,000_Aeronautica_Imperialis.gst
+++ b/Warhammer_40,000_Aeronautica_Imperialis.gst
@@ -79,6 +79,9 @@
   </forceEntries>
   <sharedSelectionEntries>
     <selectionEntry id="9212-4467-e7a2-ed52" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0be3-47af-a64c-dba0" type="max"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry id="05ff-c1dc-6058-b39b" name="Aerial Predator" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/Warhammer_40,000_Aeronautica_Imperialis.gst
+++ b/Warhammer_40,000_Aeronautica_Imperialis.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="df04-c447-f12b-fae8" name="Warhammer 40,000: Aeronautica Imperialis" revision="18" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="df04-c447-f12b-fae8" name="Warhammer 40,000: Aeronautica Imperialis" revision="19" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="7ca4-c4f1-d97e-2820" name="Taros Air War"/>
     <publication id="41a0-328f-4c30-b6fa" name="Aeronautica Imperialis – Companion" publicationDate="2022"/>
@@ -53,6 +53,11 @@
         <characteristicType id="f27e-c1a3-3770-bf93" name="Ability"/>
       </characteristicTypes>
     </profileType>
+    <profileType id="66b0-ed2e-b79e-a16e" name="Ace Ability">
+      <characteristicTypes>
+        <characteristicType id="0bfa-7538-cf12-4cbc" name="Description"/>
+      </characteristicTypes>
+    </profileType>
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="eea0-ed0b-e00c-b07c" name="Fighter" hidden="false"/>
@@ -72,6 +77,320 @@
       </categoryLinks>
     </forceEntry>
   </forceEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="2b40-fac7-feda-7c95" name="Aerial Predator" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ee90-e85b-e6cb-6e0f" name="Aerial Predator" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level below it.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="4.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0acb-a7ca-1a8b-ff7e" name="Out of the Sun" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6493-5acd-04a2-9d52" name="Out of the Sun" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the Initiative roll if this aircraft is at a higher Altitude level than all enemy aircraft during the Initiative phase. A maximum of 1 can be added to the roll no matter how many pilots have this ability.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df3e-9e42-f02f-5518" name="Precision Bombing" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="656c-cf3d-29a9-cd09" name="Precision Bombing" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When making a Bombing Run, this aircraft adds +2 to the hit roll if there is only one level of Altitude difference between it and its target rather than the usual +1.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3f4-5a43-9f57-59ab" name="Cool-headed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="5ad0-ecb9-6179-3912" name="Cool-headed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Stall with this aircraft.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4cb1-1c8e-3c68-98b2" name="Deadly Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f47d-6e27-42ad-55ba" name="Deadly Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when resolving Tailing Fire.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d80e-84a9-9d98-71c8" name="Dead-eye" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7c33-0fb9-bc07-8412" name="Dead-eye" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Short range.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc94-5fe4-d040-2839" name="Punch It!" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="638f-a0cd-8a10-da8e" name="Punch It!" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may add +1 to it Throttle characteristic when increasing Speed during the Throttle step of the Movement phase.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c02c-819b-9938-830c" name="Defensive Manoeuvre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="33c0-89ce-f8b6-77e5" name="Defensive Manoeuvre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per turn, one enemy aircraft must discard one successful hit dice roll when targeting this aircraft.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b27-b64a-74ed-33a2" name="Superior Reactions" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a9e8-00e0-a84d-b453" name="Superior Reactions" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when this aircraft is activated during the Movement phase, it may discard its Manoeuvre token and immediately choose another Ace Manoeuvre.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b55e-a77c-9b57-3713" name="Enhanced Targeting" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8c3e-f078-d099-2799" name="Enhanced Targeting" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft travelling at a ghigher Speed than it.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e111-92b7-42fb-ecdd" name="No Fear" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6d52-2324-67d8-2464" name="No Fear" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Should this aircraft suffer any damaging hits as a result of ending its movement in a hex occupied by another aircraft, roll a D6 for each hit. For each roll of a 5+, a single damaging hit is ignored and the Structure point(s) that would have been lost as a result of the Damage dice are not lost.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c493-09e6-bd9b-ab94" name="Survival Instinct" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2409-a017-a6e8-fbf5" name="Survival Instinct" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add 1 to the dice roll when testing to recover from a Spin with this aircraft.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="08f0-8fe5-1051-32b2" name="Large Calibre" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="382e-4456-9ef8-1736" name="Large Calibre" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, this aircraft may improve the Damage characteristic of one of its weapons by 1.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3109-c829-5826-76a5" name="Ground Attack Specialist" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e4ab-8c89-f874-b494" name="Ground Attack Specialist" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, when firing a weapon with the Ground Attack special rule, this aircraft may re-roll any of the Firepower dice that roll a 1 to hit.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f1ec-1cb5-a366-eac0" name="Fly By" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="99d4-33d0-7e0d-e448" name="Fly By" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all Short range hit rolls made by this aircraft when targeting enemy aircraft travelling at a lower Speed than it.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="824b-31cb-e74a-9ab3" name="Stealthy Hunter" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1b4a-c41c-ca0c-2eeb" name="Stealthy Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this aircraft when targeting enemy aircraft at one Altitude level above it.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="4.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc67-3b0e-60ac-1ba3" name="Crack Shot" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6e58-74f7-4755-2c7b" name="Crack Shot" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, after rolling the Firepower dice but before rolling the Damage dice, this aircraft may choose to improve the Damage characteristic of one of its weapons by 1.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="4.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5acf-4a09-fdea-9b16" name="Eagle-eyed" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="cef1-bdb3-bad2-3430" name="Eagle-eyed" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+          <characteristics>
+            <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">This aircraft may roll one extra dice when firing at Long range.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="4.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="513e-d0ec-52f3-de73" name="Expanded Ace Abilities" publicationId="41a0-328f-4c30-b6fa" page="52-53" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="414f-ac52-3539-9865" name="Aerial Predator" hidden="false" collective="false" import="true" targetId="2b40-fac7-feda-7c95" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8e-fdd0-fcb4-34dd" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="edc2-fa42-672b-183a" name="Cool-headed" hidden="false" collective="false" import="true" targetId="d3f4-5a43-9f57-59ab" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab8c-da25-cb38-e93b" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ca90-d067-b51a-37c8" name="Crack Shot" hidden="false" collective="false" import="true" targetId="dc67-3b0e-60ac-1ba3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0501-f36b-e18b-943c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="641e-735f-d999-224a" name="Dead-eye" hidden="false" collective="false" import="true" targetId="d80e-84a9-9d98-71c8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8029-05da-8418-8f3f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="71a9-cb3a-9f90-cf24" name="Deadly Hunter" hidden="false" collective="false" import="true" targetId="4cb1-1c8e-3c68-98b2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="138e-561a-0918-06d0" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="e82a-95f7-515b-4d12" name="Defensive Manoeuvre" hidden="false" collective="false" import="true" targetId="c02c-819b-9938-830c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0b7-d384-45c2-23d3" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="497c-cde4-935e-7360" name="Eagle-eyed" hidden="false" collective="false" import="true" targetId="5acf-4a09-fdea-9b16" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="981b-0b0b-7b0f-99e8" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="dd97-4c16-6d5d-ead0" name="Enhanced Targeting" hidden="false" collective="false" import="true" targetId="b55e-a77c-9b57-3713" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00b8-08cc-01f4-fe8d" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4963-495a-cbf2-eac3" name="Fly By" hidden="false" collective="false" import="true" targetId="f1ec-1cb5-a366-eac0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43f-0944-d17e-43df" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c38e-6298-0f21-80fb" name="Ground Attack Specialist" hidden="false" collective="false" import="true" targetId="3109-c829-5826-76a5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1c4-cfad-e64f-8631" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b7fa-d015-51f1-f12a" name="Large Calibre" hidden="false" collective="false" import="true" targetId="08f0-8fe5-1051-32b2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f1c-ecb1-3c9f-773c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9abd-04d2-f836-dbae" name="No Fear" hidden="false" collective="false" import="true" targetId="e111-92b7-42fb-ecdd" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b5-4c7d-94b4-e27c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2db8-6570-6ebf-3ad5" name="Out of the Sun" hidden="false" collective="false" import="true" targetId="0acb-a7ca-1a8b-ff7e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93c0-1cb6-6f8c-7eca" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9491-f041-8e10-99b8" name="Precision Bombing" hidden="false" collective="false" import="true" targetId="df3e-9e42-f02f-5518" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f88-dee2-5ece-d7c2" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5bd3-cafb-9408-09ab" name="Punch It!" hidden="false" collective="false" import="true" targetId="fc94-5fe4-d040-2839" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91d0-2a26-e243-07e9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="7e28-ba24-7c52-8995" name="Stealthy Hunter" hidden="false" collective="false" import="true" targetId="824b-31cb-e74a-9ab3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa7c-dc9f-0dd5-219e" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="7784-92ce-a601-af68" name="Superior Reactions" hidden="false" collective="false" import="true" targetId="1b27-b64a-74ed-33a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a41f-c173-16d0-482d" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6ea5-0d3b-24d5-35d6" name="Survival Instinct" hidden="false" collective="false" import="true" targetId="c493-09e6-bd9b-ab94" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a5-f094-389c-0259" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="7406-f5b9-a751-1291" name="Jump troops" hidden="false">
       <description>Instead of landing in a landing zone, a transport aircraft with Jump Troops can drop them from altitude as it passes over. To drop its Jump Troops, the aircraft must pass directly over the landing zone during the Move and Manoeuvre step of the Movement phase. Once the aircraft has completed its movement, before adjusting Altitude roll a D6 for each point of transport capacity being dropped. If the result of the roll is higher than the aircraft’s current Altitude and Speed added together, the Jump Troops land safely within the landing zone and Victory points are scored. If however the result of the roll is equal to or lower than the aircraft’s current Speed and Altitude added together, the troops are scattered, injured or killed and no Victory points are scored.</description>
@@ -83,7 +402,7 @@
       <description>Once this aircraft had deployed its cargo, it may Voluntarily Disengage in any turn as if it were the Disengagement turn.</description>
     </rule>
     <rule id="e966-31c6-4527-8a39" name="Jink" hidden="false">
-      <description>When this aircraft is chosen to fire during the Firing phase, before step 1: Targeting, it may immediately move one hex in any direction. 
+      <description>When this aircraft is chosen to fire during the Firing phase, before step 1: Targeting, it may immediately move one hex in any direction.
 Note, however, that the aircraft may not change its facing, Altitude or Speed after making this move, nor may this movement take the aircraft into an occupied hex.</description>
     </rule>
     <rule id="b340-7f0b-16d2-170b" name="Stealth (-1)" hidden="false">


### PR DESCRIPTION
Add the abilities to every non-Ace plane in the game. Also limit each plane to
taking each ability only once, even if that is allowed RAW.

Closes #66  

<img width="837" alt="Screen Shot 2022-02-21 at 12 50 55 AM" src="https://user-images.githubusercontent.com/2727124/154897069-54fccfe9-80fa-48ea-9e8a-175f4f51d4cd.png">
<img width="831" alt="Screen Shot 2022-02-21 at 12 51 17 AM" src="https://user-images.githubusercontent.com/2727124/154897076-2bceb8bb-03c8-4490-9d5b-f502cd7af80c.png">
<img width="630" alt="Screen Shot 2022-02-21 at 12 51 27 AM" src="https://user-images.githubusercontent.com/2727124/154897078-d98e3062-c6dc-45e0-989e-c5763d59bd47.png">

