### PR TITLE
fix: Separate the Campaign Ace abilities

### DIFF
--- a/Adeptus_Astartes.cat
+++ b/Adeptus_Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="13" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9826-b91b-6a9d-ca70" name="Adeptus Astartes" revision="14" battleScribeVersion="2.03" authorName="Fire Raptor" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="25d1-4c56-7d01-fd5b" name="Wrath of Angels" publicationDate="2021"/>
   </publications>
@@ -61,6 +61,7 @@
         <entryLink id="520b-1557-d9fd-80d0" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
         <entryLink id="b975-4454-ddff-314f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="8d61-210b-1218-c97f" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="ca2f-2733-63a2-95db" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -202,6 +203,7 @@
         <entryLink id="9e1d-bc2c-94c4-b172" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
         <entryLink id="cd14-c68c-8da5-6a2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="314c-bfb1-d9b9-8b38" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="8a72-b8aa-f139-a5d2" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="29.0"/>
@@ -407,6 +409,7 @@
         <entryLink id="7972-a241-0089-a6e2" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
         <entryLink id="5d69-f642-6c22-4276" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="78c6-e858-c25c-157d" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="4b7a-4d16-d04f-a40f" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="31.0"/>
@@ -641,6 +644,7 @@
         <entryLink id="3736-5dff-a152-a992" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="323a-9cee-3091-0308" type="selectionEntryGroup"/>
         <entryLink id="94d7-f35a-3822-9f8e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="a03a-07cd-2e94-5502" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="058d-8718-dc6b-8c51" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="44.0"/>

--- a/Aeldari_Asuryani.cat
+++ b/Aeldari_Asuryani.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="80cf-6e69-8bf6-d62e" name="Asuryani" revision="7" battleScribeVersion="2.03" authorName="Updated Companion Stats" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="80cf-6e69-8bf6-d62e" name="Asuryani" revision="8" battleScribeVersion="2.03" authorName="Updated Companion Stats" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="1d81-06ef-f102-6d15" name="Wrath of Angels"/>
     <publication id="1ef7-1236-3c3d-7e72" name="Aeronautica Imperialis – Companion" shortName="Companion" publisher="Aeronautica Imperialis – Companion" publicationDate="2022" publisherUrl="https://www.games-workshop.com/en-CA/aeronautica-imperialis-companion-eng-2022"/>
@@ -191,6 +191,7 @@
         <entryLink id="3aac-ff5d-a7fd-6aac" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
         <entryLink id="5fb6-28f5-44f0-f937" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="ae0b-5df2-1583-c4b5" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="e364-8ba2-3a77-8107" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -269,6 +270,7 @@
         <entryLink id="15ad-7e56-1233-077b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
         <entryLink id="cb55-7761-3aad-a837" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="b00e-a401-b132-6fbd" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="672c-9ae4-0420-51f2" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -477,6 +479,7 @@
         </entryLink>
         <entryLink id="5826-0768-f1e6-4b20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="4b76-dc6e-c00e-e17e" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="975d-e41d-5cfb-6066" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -545,6 +548,7 @@
         <entryLink id="0f01-06ed-e964-ad6e" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
         <entryLink id="cb4e-4367-1aef-19a3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="731d-c720-919e-d0a8" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="5da8-1ca7-9809-cd41" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -656,6 +660,7 @@
         <entryLink id="4493-2b67-4f9e-6db9" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
         <entryLink id="3227-3b87-29e5-e3cc" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="3e82-258e-3d57-0a8b" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="8b0c-379c-7a26-e460" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>
@@ -721,6 +726,7 @@
         <entryLink id="5c83-57c9-3634-5d74" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="d04a-60cb-9037-6636" type="selectionEntryGroup"/>
         <entryLink id="2226-490f-9896-b828" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="ac1b-03c2-3e51-eb62" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="48ce-833c-6288-4a7f" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="36.0"/>

--- a/Astra_Militarum.cat
+++ b/Astra_Militarum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="63fd-f1bb-e3ca-e39f" name="Astra Militarum" revision="6" battleScribeVersion="2.03" authorName="Valkyrie Assault Craft" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="63fd-f1bb-e3ca-e39f" name="Astra Militarum" revision="7" battleScribeVersion="2.03" authorName="Valkyrie Assault Craft" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="9474-faac-1eb5-889b" name="Valkyrie Assault Craft" hidden="false" collective="false" import="true" type="model">
       <modifiers>
@@ -136,6 +136,7 @@
         <entryLink id="b7b2-4a5f-829b-9f91" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
         <entryLink id="4c0e-19ea-a2dd-f376" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="d6f4-1383-b0d1-9773" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="4772-019e-0212-d406" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -305,6 +306,7 @@
         <entryLink id="4aff-27bb-a50b-192f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="5c80-073d-0f8c-8dc6" type="selectionEntryGroup"/>
         <entryLink id="5a5e-d33a-79b3-4e2a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="2e9d-5e07-37da-c6e4" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="8172-53cb-055c-9e7c" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>

--- a/Imperial_Navy.cat
+++ b/Imperial_Navy.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="27" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5745-5a5f-07b9-7f4f" name="Imperial Navy" revision="28" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="583d-7042-2316-f8b5" name="White Dwarf October 2019"/>
     <publication id="39ba-445a-a65f-2bd6" name="White Dwarf November 2020"/>
@@ -68,6 +68,7 @@
         <entryLink id="2f34-5a54-3085-8855" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="804b-835e-7125-e869" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="dda5-edd5-333d-e131" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="4dcf-45dc-0843-cb6a" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -136,6 +137,7 @@
         <entryLink id="d5fd-4934-7cf9-07bc" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="0003-a8cd-ed9d-69b8" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="e7b7-8847-2fc6-5401" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="6624-43c0-3adf-b16e" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -203,6 +205,7 @@
         <entryLink id="a19e-a3c6-eeb9-7f4f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="99f4-f322-2e40-8cca" name="Emperor&apos;s Blessing" hidden="false" collective="false" import="true" targetId="f1c0-2a50-662b-f1b4" type="selectionEntry"/>
         <entryLink id="b704-d5dd-efdc-1ecf" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="924c-3366-0d0f-2a49" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -317,6 +320,7 @@
         <entryLink id="f19e-ca4e-54f4-b678" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="3932-5571-c9ac-f8a6" name="Emperor&apos;s Blessing" hidden="false" collective="false" import="true" targetId="f1c0-2a50-662b-f1b4" type="selectionEntry"/>
         <entryLink id="33c7-5c0e-aa38-ca1f" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="1ceb-3fc7-7bf7-637c" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="27.0"/>
@@ -648,6 +652,7 @@
         <entryLink id="c487-1d86-ca05-2d39" name="Avenger Bolt Cannon" hidden="false" collective="false" import="true" targetId="9543-aa37-4ab4-90ad" type="selectionEntry"/>
         <entryLink id="0376-61b7-f7bc-24b5" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="7899-9b67-e6c2-27c7" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="43c7-9ac5-865c-5d05" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -750,6 +755,7 @@
         <entryLink id="7e06-d2b4-0a5d-8035" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="3f33-5b82-00d3-9134" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="f2dc-0764-0467-0f3c" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="9c1e-a43b-7106-b978" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="19.0"/>
@@ -783,6 +789,7 @@
         <entryLink id="60a3-2ebb-1a8a-bfcf" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="b890-18e0-99ff-65b2" type="selectionEntryGroup"/>
         <entryLink id="9473-df52-deed-d37f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="a5d8-a208-9726-09c4" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="b1c0-68a3-b7fa-8992" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
@@ -949,6 +956,7 @@
         <entryLink id="b815-d515-35e6-9daf" name="Heavy Bolter Array" hidden="false" collective="false" import="true" targetId="c35c-4da1-1099-b325" type="selectionEntry"/>
         <entryLink id="234d-2f97-3ecb-3d20" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="031c-654b-35d9-d32a" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="68f9-687b-6a05-6aab" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="26.0"/>
@@ -1002,6 +1010,7 @@
         <entryLink id="be3e-e330-38d7-e2a5" name="Crew" hidden="false" collective="false" import="true" targetId="ea59-501a-a451-ec37" type="selectionEntryGroup"/>
         <entryLink id="9811-fcc3-a179-50e3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="a6cf-7e44-86fc-0d4a" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="ccef-b475-bf2b-4c5f" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="33.0"/>

--- a/Necron.cat
+++ b/Necron.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a13a-71d9-db49-a498" name="Necrons" revision="7" battleScribeVersion="2.03" authorName="Necron aircraft upgrades" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a13a-71d9-db49-a498" name="Necrons" revision="8" battleScribeVersion="2.03" authorName="Necron aircraft upgrades" authorContact="@evanh" authorUrl="" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="41a0-328f-4c30-b6fa" name="Aeronautica Imperialis – Companion" shortName="Companion" publisher="Aeronautica Imperialis – Companion" publicationDate="2022" publisherUrl="https://www.games-workshop.com/en-CA/aeronautica-imperialis-companion-eng-2022"/>
   </publications>
@@ -34,6 +34,7 @@
         <entryLink id="6693-6551-76de-399c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="2bf8-1b90-1e36-81f9" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
         <entryLink id="ab4e-6a73-0599-934d" name="Heavy Death Ray" hidden="false" collective="false" import="true" targetId="5c1e-d563-97ac-f14a" type="selectionEntry"/>
+        <entryLink id="f77e-2791-11ae-6dcf" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="38.0"/>
@@ -93,6 +94,7 @@
         <entryLink id="2136-0bd3-ca46-7e7c" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
         <entryLink id="b880-20b6-5d0f-c3b3" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="5e70-0001-f694-27ba" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="949d-92cd-d4c2-50d7" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="39.0"/>
@@ -127,6 +129,7 @@
         <entryLink id="a3ac-35f6-6f8b-ea4f" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="7e3a-2d3d-4c63-9157" type="selectionEntryGroup"/>
         <entryLink id="6ac5-6326-0d73-3829" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="9726-2f7b-2698-cec2" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="da21-5ea4-56b6-96e0" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>

--- a/Ork_Air_Waaagh.cat
+++ b/Ork_Air_Waaagh.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="36" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0743-d0bd-bfee-c92a" name="Ork Air Waaagh!" revision="37" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="583d-7042-2316-f8b5" name="White Dwarf October 2019"/>
     <publication id="22c5-f0a4-5370-5716" name="White Dwarf December 2019"/>
@@ -227,6 +227,7 @@
         <entryLink id="bdc3-540a-c180-2afb" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
         <entryLink id="cf70-b292-660a-f695" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="758f-01bf-f54c-773f" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="7161-eecd-0e1c-ee7c" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>
@@ -412,6 +413,7 @@
         <entryLink id="fc09-69c3-0013-2f3f" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
         <entryLink id="93b3-3d68-5b28-5e63" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="1ce8-ac3e-9d4b-c50b" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="5582-565a-767f-eeec" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -522,6 +524,7 @@
         <entryLink id="2e38-d153-3519-07cc" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
         <entryLink id="6eb6-5b04-19f7-4a11" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="3599-0ea1-5be7-e880" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="8740-45e4-165a-9a9d" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -697,6 +700,7 @@
         </entryLink>
         <entryLink id="639b-ace7-b219-4b4b" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="a2be-600e-cc8b-7150" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="9762-c9cf-6540-0c43" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -1139,6 +1143,7 @@
         <entryLink id="86a7-eda8-b83b-58b1" name="Aircraft upgrade" hidden="false" collective="false" import="true" targetId="54a6-483f-3fbb-cf60" type="selectionEntryGroup"/>
         <entryLink id="1108-6e8b-c5b1-dddd" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="ff2d-c49e-542a-bdb7" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="8b9a-a20d-90f5-d32b" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="51.0"/>
@@ -1240,6 +1245,7 @@
         <entryLink id="50cf-85b3-ea0a-8a7d" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
         <entryLink id="1d4a-0f6d-f9e7-5d30" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="3350-bd70-21ee-b141" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="6629-98d9-56fe-ff2b" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -1384,6 +1390,7 @@
         <entryLink id="e2f4-1edb-8425-4671" name="Crew" hidden="false" collective="false" import="true" targetId="ea21-b91d-7237-b2b0" type="selectionEntryGroup"/>
         <entryLink id="6f8e-60f8-cbb5-2490" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="5f0c-cbf6-fcd4-62a6" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="6256-ac4b-fded-efe0" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>

--- a/Tau_Air_Caste.cat
+++ b/Tau_Air_Caste.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6088-0c35-9d44-ed62" name="T&apos;au Air Caste" revision="10" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="21" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6088-0c35-9d44-ed62" name="T&apos;au Air Caste" revision="11" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" authorUrl="https://discord.gg/KqPVhds" library="false" gameSystemId="df04-c447-f12b-fae8" gameSystemRevision="22" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="8fd6-64b7-db74-8a38" name="Tau" hidden="true"/>
     <categoryEntry id="8b49-06f2-7beb-4695" name="Auxiliary" hidden="true">
@@ -142,6 +142,7 @@
         </entryLink>
         <entryLink id="482f-29af-7520-0e10" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="e6c0-bf83-cd60-e9ae" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="298f-4c60-c6eb-dc79" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -263,6 +264,7 @@
         </entryLink>
         <entryLink id="ce36-de89-b709-3ba9" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="2238-d155-da67-1f76" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="3f19-c0d0-e624-dc79" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="24.0"/>
@@ -351,6 +353,7 @@
         <entryLink id="42cf-0fb3-322e-ee75" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
         <entryLink id="cc61-9d4b-806b-842e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="b063-ff95-2375-e40a" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="3ab0-82a9-34ed-8b20" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="28.0"/>
@@ -441,6 +444,7 @@
         <entryLink id="79cc-25a8-8336-846b" name="Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="6f30-104f-c5f0-970b" type="selectionEntryGroup"/>
         <entryLink id="aecf-0800-5663-5e4c" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="a63d-fbea-8c7f-182f" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="0b7f-33cc-829d-0432" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="14.0"/>
@@ -701,6 +705,7 @@
         <entryLink id="8815-1dc9-41e3-b8f2" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="caa5-2340-7d43-e00f" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="c601-40f8-0185-ccd2" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="11d4-ff5e-44c9-be66" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -858,6 +863,7 @@
         <entryLink id="8720-456f-7f2a-07a0" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="8edc-6648-debd-9f7e" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="9434-52e0-fc7c-7efa" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="6a75-5796-5e90-4b0d" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="23.0"/>
@@ -918,6 +924,7 @@
         <entryLink id="707b-aecc-053d-e0b1" name="Twin Lascannons" hidden="false" collective="false" import="true" targetId="ba94-bb2f-2e9c-b955" type="selectionEntry"/>
         <entryLink id="06fa-385f-7ccc-2686" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="fcec-4e22-9a4c-eecd" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="f16f-d3b8-c184-3013" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="22.0"/>
@@ -1070,6 +1077,7 @@
         <entryLink id="52da-e0c0-78bf-7804" name="Human Auxiliary Crew" hidden="false" collective="false" import="true" targetId="bdc5-b41f-7fdb-9ce9" type="selectionEntryGroup"/>
         <entryLink id="68cc-b9cd-b86c-a16a" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="8ec9-fa0a-d7a4-8484" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="c555-6ed9-d457-cc22" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -1266,6 +1274,7 @@
       <entryLinks>
         <entryLink id="46bc-8370-1d66-2d07" name="Expanded Ace Abilities" hidden="false" collective="false" import="true" targetId="9212-4467-e7a2-ed52" type="selectionEntry"/>
         <entryLink id="0b19-ec02-a7d3-fdfb" name="Custom Aircraft Upgrades" hidden="false" collective="false" import="true" targetId="fa55-16f8-1abb-3626" type="selectionEntry"/>
+        <entryLink id="a1f8-dbf4-43e4-2912" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" targetId="005b-c464-c070-94d7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="16.0"/>

--- a/Warhammer_40,000_Aeronautica_Imperialis.gst
+++ b/Warhammer_40,000_Aeronautica_Imperialis.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="df04-c447-f12b-fae8" name="Warhammer 40,000: Aeronautica Imperialis" revision="21" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="df04-c447-f12b-fae8" name="Warhammer 40,000: Aeronautica Imperialis" revision="22" battleScribeVersion="2.03" authorName="BSDevelopers" authorContact="@Water" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="7ca4-c4f1-d97e-2820" name="Taros Air War"/>
     <publication id="41a0-328f-4c30-b6fa" name="Aeronautica Imperialis – Companion" publicationDate="2022"/>
@@ -354,246 +354,6 @@
             <cost name="pts" typeId="points" value="1.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e2b5-f949-401d-e3a2" name="Bird of Prey" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4112-9ad7-fac0-5e59" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="4a9e-2474-9df2-224d" name="Bird of Prey" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Long range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Long range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Bird of Prey ability has no effect for the remainder of the game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="99b5-3c9f-e85c-8516" name="Superior Hunter" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72c7-9cdf-264a-fce0" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="9315-901a-9c74-6a9f" name="Superior Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when resolving Tailing Fire. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when resolving Tailing Fire; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Superior Hunter ability has no effect for the remainder of the game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ce30-a512-9dbb-5430" name="Dive Bomber" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3204-f738-f727-3b4b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d9b6-4353-a3e4-c7df" name="Dive Bomber" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at at a ground target or an aircraft at Altitude 0. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at a ground target; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Dive Bomber ability has no effect for the remainder of the game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="1.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c521-7cc8-093d-6ec5" name="Superior Commander" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="504c-1dc1-3e7d-1ce1" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="137e-b632-9ec7-c2b6" name="Superior Commander" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, before rolling for initiative, you can choose to win the initiative. The aircraft piloted by a pilot with this ability must be within the Area of Engagement to use this ability. If both forces have an Ace with this ability, the player who did not have initiative last round can declare that they will use this ability first; if they do so, the opposing force cannot use it that round. A force can only use this ability once per game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8c3c-ae30-6938-3201" name="Steady" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6960-0d79-eed7-e5a2" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5b6b-ce60-7b5a-18df" name="Steady" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Medium range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Medium range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Steady ability has no effect for the remainder of the game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="fda4-9c4e-16f7-1d99" name="Aerial Master" publicationId="41a0-328f-4c30-b6fa" page="53-54" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb4-4f86-9963-861a" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="3193-572b-8230-566f" name="Aerial Master" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, when you reveal the Ace Manoeuvre of the pilot&apos;s aircraft, you may exchange it for another Ace Manoeuvre numbered one higher or one lower (e.g. a 3 could become a 2 or a 4). It must be an Ace Manoeuvre that the aircraft can normally perform.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="3.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4fd4-0a32-361c-af8b" name="Watch This!" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc30-65c0-bcbe-eba9" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d08d-9607-dbe9-dbd2" name="Watch This!" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">If this pilot is included in a force that is victorious, choose one pilot (other than the pilot with this ability) to gain an additional 1 experience or D3 experience if this pilot killed at least one enemy aircraft.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="1.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2946-2c3c-7ecf-326d" name="Up Close and Personal" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28e5-a2d4-1439-5aa3" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="93c7-b71b-e9dd-3ff0" name="Up Close and Personal" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Short range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Short range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Up Close and Personal ability has no effect for the remainder of the game.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="47b0-bf09-4866-597e" name="Sky Devil" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a3c-f196-0d8b-a956" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6bd2-318d-e46d-0ccc" name="Sky Devil" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this pilot&apos;s aircraft when targeting enemy aircraft at one Altiude below it; this does not apply when targeting ground targets. An aircraft cannot have both this ability and Death from Below.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="84db-a00b-d9e2-8017" name="Death From Below" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f74d-7ce5-4b38-334b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="0bdd-9477-52b9-8474" name="Death From Below" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this pilot&apos;s aircraft when targeting enemy aircraft at one Altiude above it. An aircraft cannot have both this ability and Sky Devil.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="eff5-053c-8b09-a0eb" name="Stealthy" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17f2-917d-29f5-758b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6b27-b9db-852c-b20e" name="Stealthy" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When chosen as a target by an emeny aircraft, the controlling player can choose for the pilot&apos;s aircraft to count as one hex further from the firing aircraft than normal (e.g. if the target if four hexes from the firing aircraft, it counts as five and would thus be at Medium range).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="cefc-4d5e-ca67-900d" name="Trigger Happy" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99e4-8e3a-3543-63c7" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="09d4-8d17-d985-2eb7" name="Trigger Happy" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, this pilot&apos;s aircraft may fire twice with a weapon. The chosen weapon must have an Ammo characteristic other than UL. This second shot is resolved as normal, expends ammunition, etc. Upgrades with the same name (such as two sets of Skystrike Missiles) count as separate weapons.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="469d-0af5-c6de-aa42" name="Mechanical Genius" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f691-a8dd-3367-64f6" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="b88e-f24b-e263-9f29" name="Mechanical Genius" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, this pilot&apos;s aircraft may attempt a repair. During the End phase, roll a D6 for each lost point of Structure. For each roll of a 6+, repair a single point of Structure.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="4.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ff76-6ca2-9609-5d00" name="Munitions Expert" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ac8-c464-3d31-6c89" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="7349-2d92-e26f-0ad0" name="Munitions Expert" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When this pilot&apos;s aircraft is deployed, choose one weapon it is equipped with that has an Ammo characteristic other than UL. For the remainder of the game, increase that weapon&apos;s Damage characteristic by 1 to a maximum of 2+. Upgrades with the same name (such as two sets of Skystrike missiles) count as separate weapons.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="3.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="84c1-0ecd-266d-e3c7" name="Lucky" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dab8-00d9-5f75-183f" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="006d-cb4e-0129-9773" name="Lucky" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">If this pilot&apos;s aircraft is shot down in a game during the course of a campaign, the pilot and aircraft survive on a 2+ instead of the usual 5+. On a 1, both the pilot and aircraft are lost.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="1.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5c4b-1696-f20f-82d9" name="Fly-by Shooter" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce1f-4d12-5035-fc33" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5906-60ef-17ad-2673" name="Fly-by Shooter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
-              <characteristics>
-                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, this pilot&apos;s aircraft may fire one weapon after it finishes moving during the Movement phase. It can only fire at a target in the aircraft&apos;s Rear Arc and the target must be within Short range.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="3.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -774,6 +534,256 @@
             <profile id="9980-763d-b37a-4cc6" name="Grav Chutes" hidden="false" typeId="9f87-657f-61ed-3e6b" typeName="Aircraft Upgrade">
               <characteristics>
                 <characteristic name="Ability" typeId="f27e-c1a3-3770-bf93">An aircraft with a Transport characteristic other (--) can purchase this upgrade. The aircraft gains the Jump Troops special rule if it did not already have it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="005b-c464-c070-94d7" name="Campaign Ace Abilities" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3367-ce2b-face-f4cb" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2d03-b5d0-10c3-64f3" name="Bird of Prey" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2721-dd14-a7fe-a78e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6fee-6180-f2f3-43b3" name="Bird of Prey" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Long range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Long range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Bird of Prey ability has no effect for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="500b-4b8e-fdd9-9f5d" name="Superior Hunter" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f985-f74c-8675-f41f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="474d-7398-ea6a-fded" name="Superior Hunter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when resolving Tailing Fire. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when resolving Tailing Fire; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Superior Hunter ability has no effect for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f6ba-9bc9-4ae4-69d5" name="Dive Bomber" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1765-7735-ffc8-d7d7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="42b3-ee02-95ac-f12a" name="Dive Bomber" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at at a ground target or an aircraft at Altitude 0. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at a ground target; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Dive Bomber ability has no effect for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ec3-9261-3907-69c6" name="Superior Commander" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5260-bdc0-7a72-08a3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6798-4c09-23cc-80e6" name="Superior Commander" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, before rolling for initiative, you can choose to win the initiative. The aircraft piloted by a pilot with this ability must be within the Area of Engagement to use this ability. If both forces have an Ace with this ability, the player who did not have initiative last round can declare that they will use this ability first; if they do so, the opposing force cannot use it that round. A force can only use this ability once per game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a2a1-e0e2-88b6-ee95" name="Steady" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c906-7d56-7eab-ce1b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fc54-b48e-65df-df1f" name="Steady" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Medium range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Medium range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Steady ability has no effect for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e94e-8da1-549f-5b02" name="Aerial Master" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bea-f42c-3f28-7e16" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="86b1-f2a3-9634-8ad8" name="Aerial Master" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, when you reveal the Ace Manoeuvre of the pilot&apos;s aircraft, you may exchange it for another Ace Manoeuvre numbered one higher or one lower (e.g. a 3 could become a 2 or a 4). It must be an Ace Manoeuvre that the aircraft can normally perform.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1c71-1567-4b17-0fa0" name="Watch This!" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2300-9dc6-f12f-6cb7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a026-45ad-167e-f19c" name="Watch This!" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">If this pilot is included in a force that is victorious, choose one pilot (other than the pilot with this ability) to gain an additional 1 experience or D3 experience if this pilot killed at least one enemy aircraft.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c31-80a6-2fce-a7cf" name="Up Close and Personal" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9300-7aed-252d-3f09" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="825f-bc22-b8e8-f583" name="Up Close and Personal" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, the pilot&apos;s aircraft may roll one extra dice when firing at Short range. In addition, once per game, the aircraft may choose to re-roll any number of dice from a dice roll when firing at Short range; the player must accept the result of the second roll, even if it is worse. Once this re-roll has been used, the Up Close and Personal ability has no effect for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6dc4-c687-82c6-a60a" name="Sky Devil" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa1a-5ea0-e287-f0a3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d29f-3ea9-3c6f-4041" name="Sky Devil" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this pilot&apos;s aircraft when targeting enemy aircraft at one Altiude below it; this does not apply when targeting ground targets. An aircraft cannot have both this ability and Death from Below.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cfe1-cf41-a8c9-fc15" name="Death From Below" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1645-5f96-6049-ac9e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e02b-2548-0320-26ac" name="Death From Below" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Add +1 to all hit rolls made by this pilot&apos;s aircraft when targeting enemy aircraft at one Altiude above it. An aircraft cannot have both this ability and Sky Devil.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4b16-bb90-0bea-c0d4" name="Stealthy" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd6e-b3e8-823a-3d0d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dddc-2d5d-473b-e817" name="Stealthy" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When chosen as a target by an emeny aircraft, the controlling player can choose for the pilot&apos;s aircraft to count as one hex further from the firing aircraft than normal (e.g. if the target if four hexes from the firing aircraft, it counts as five and would thus be at Medium range).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="abea-042b-192b-adca" name="Trigger Happy" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6605-86a3-e581-abd4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="813a-4fc2-f4a8-7f29" name="Trigger Happy" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, this pilot&apos;s aircraft may fire twice with a weapon. The chosen weapon must have an Ammo characteristic other than UL. This second shot is resolved as normal, expends ammunition, etc. Upgrades with the same name (such as two sets of Skystrike Missiles) count as separate weapons.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e57a-e093-6a70-f286" name="Mechanical Genius" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ef-50dc-0b63-592f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="567e-4aa1-fd83-37e0" name="Mechanical Genius" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per game, this pilot&apos;s aircraft may attempt a repair. During the End phase, roll a D6 for each lost point of Structure. For each roll of a 6+, repair a single point of Structure.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2db7-e45b-a2e0-91ea" name="Munitions Expert" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102d-903d-ca11-60d8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="40cc-8d03-5c4d-3d1c" name="Munitions Expert" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">When this pilot&apos;s aircraft is deployed, choose one weapon it is equipped with that has an Ammo characteristic other than UL. For the remainder of the game, increase that weapon&apos;s Damage characteristic by 1 to a maximum of 2+. Upgrades with the same name (such as two sets of Skystrike missiles) count as separate weapons.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3c7f-33cc-c6c1-d56c" name="Lucky" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7b5-5f78-7d36-7bac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="54f5-8a5d-c35c-3911" name="Lucky" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">If this pilot&apos;s aircraft is shot down in a game during the course of a campaign, the pilot and aircraft survive on a 2+ instead of the usual 5+. On a 1, both the pilot and aircraft are lost.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f498-4034-1021-aa94" name="Fly-by Shooter" publicationId="888d-4b7c-acef-d9cb" page="124-126" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d50-18c5-c82d-7235" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1b9e-a5b8-2969-9c2d" name="Fly-by Shooter" hidden="false" typeId="66b0-ed2e-b79e-a16e" typeName="Ace Ability">
+              <characteristics>
+                <characteristic name="Description" typeId="0bfa-7538-cf12-4cbc">Once per round, this pilot&apos;s aircraft may fire one weapon after it finishes moving during the Movement phase. It can only fire at a target in the aircraft&apos;s Rear Arc and the target must be within Short range.</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
Separate the Campaign ace abilities from the WD from the regular ones to make
building campaign lists a little easier.
